### PR TITLE
feat/add-recover-panic

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -191,15 +191,6 @@ func ValidatorHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cli
 		Float64("request-time", time.Since(validatorQueryStart).Seconds()).
 		Msg("Finished querying validator")
 
-	defer func() {
-		r := recover()
-		if r != nil {
-			sublogger.
-				Error().
-				Msgf("Could not parse a validator info: %s", err)
-		}
-	}()
-
 	if value, err := strconv.ParseFloat(validator.Validator.Tokens.String(), 64); err != nil {
 		sublogger.Error().
 			Str("address", address).

--- a/validator.go
+++ b/validator.go
@@ -191,6 +191,15 @@ func ValidatorHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cli
 		Float64("request-time", time.Since(validatorQueryStart).Seconds()).
 		Msg("Finished querying validator")
 
+	defer func() {
+		r := recover()
+		if r != nil {
+			sublogger.
+				Error().
+				Msgf("Could not parse a validator info: %s", err)
+		}
+	}()
+
 	if value, err := strconv.ParseFloat(validator.Validator.Tokens.String(), 64); err != nil {
 		sublogger.Error().
 			Str("address", address).

--- a/validators.go
+++ b/validators.go
@@ -220,6 +220,15 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 		Int("validatorsLength", len(validators)).
 		Msg("Validators info")
 
+	defer func() {
+		r := recover()
+		if r != nil {
+			sublogger.
+				Error().
+				Msgf("Could not parse validators infos: %s", err)
+		}
+	}()
+
 	for index, validator := range validators {
 		// because cosmos's dec doesn't have .toFloat64() method or whatever and returns everything as int
 		rate, err := strconv.ParseFloat(validator.Commission.CommissionRates.Rate.String(), 64)

--- a/validators.go
+++ b/validators.go
@@ -225,7 +225,7 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 		if r != nil {
 			sublogger.
 				Error().
-				Msgf("Could not parse validators infos: %s", err)
+				Msgf("Could not parse validators infos: %s", r)
 		}
 	}()
 


### PR DESCRIPTION
`/metrics/validators` 매트릭 수집함에 있어서 Inconsistency한, 즉 UTF-8 형식이 아닌 밸리데이터의 Moniker를 파싱하는 과정 중 `panic`이 발생하는 경우가 종종 있습니다.
`panic`으로 인해 해당 매트릭 전부 수집이 불가하도록 로직이 설정되어 있는 점을 에러 로그를 기록하고 타 매트릭 수집은 이뤄지도록 수정했습니다.