### PR TITLE
fix: update rank sorting algo

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -581,6 +581,12 @@ func ValidatorHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cli
 			firstShares, firstErr := strconv.ParseFloat(validators[i].DelegatorShares.String(), 64)
 			secondShares, secondErr := strconv.ParseFloat(validators[j].DelegatorShares.String(), 64)
 
+			if !validators[i].IsBonded() && validators[j].IsBonded() {
+				return false
+			} else if validators[i].IsBonded() && !validators[j].IsBonded() {
+				return true
+			}
+
 			if firstErr != nil || secondErr != nil {
 				sublogger.Error().
 					Err(err).

--- a/validators.go
+++ b/validators.go
@@ -151,13 +151,14 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 			Msg("Finished querying validators")
 		validators = validatorsResponse.Validators
 
-		// sorting by delegator shares to display rankings
+		// sorting by delegator shares to display rankings (unbonded go last)
 		sort.Slice(validators, func(i, j int) bool {
-			if validators[i].DelegatorShares.BigInt().Cmp(validators[j].DelegatorShares.BigInt()) > 0 {
-				return true
-			} else {
+			if !validators[i].IsBonded() && validators[j].IsBonded() {
 				return false
+			} else if validators[i].IsBonded() && !validators[j].IsBonded() {
+				return true
 			}
+			return validators[i].DelegatorShares.BigInt().Cmp(validators[j].DelegatorShares.BigInt()) > 0
 		})
 	}()
 


### PR DESCRIPTION
Active set 우선으로 rank를 매기도록 수정하였습니다.

Inactive 상태에 대한 기준이 `Rank > Max Validator` 여서 발생했던 오탐이 해결됩니다.